### PR TITLE
datahub-base-notebook fix eliminates need to hardcode scipy/etc versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,6 @@ RUN /usr/share/datahub/scripts/install-all.sh
 RUN pip install okpy
 RUN pip install dpkt
 
-RUN conda install -y numpy==1.12.1
-RUN conda install -y pandas==0.19.2
-RUN conda install -y pypandoc
-RUN conda install -y scipy==0.19.0
-RUN conda install -y statsmodels==0.8.0
 RUN conda install --quiet --yes \
             bokeh \
             cloudpickle \


### PR DESCRIPTION
PR to datahub-base-notebook eliminates need to pin scipy/etc package versions.